### PR TITLE
Stabilization fix

### DIFF
--- a/src/constraints/DistanceConstraintData.cpp
+++ b/src/constraints/DistanceConstraintData.cpp
@@ -26,7 +26,7 @@ float DistanceConstraintData::evaluate(int constraintIndex, ParticleData &partic
     return length(p1 - p2) - distance[constraintIndex];
 }
 
-bool DistanceConstraintData::solveDistanceConstraint(glm::vec3 & delta1, glm::vec3 & delta2, int constraintIndex, ParticleData & particleData)
+bool DistanceConstraintData::solveDistanceConstraint(glm::vec3 & delta1, glm::vec3 & delta2, int constraintIndex, ParticleData & particleData, bool stabilize)
 {
     int firstParticleIndex = particles[constraintIndex].x;
     int secondParticleIndex = particles[constraintIndex].y;
@@ -40,6 +40,16 @@ bool DistanceConstraintData::solveDistanceConstraint(glm::vec3 & delta1, glm::ve
 
     if (!equality[constraintIndex] && c >= 0)
         return false;
+
+    if (stabilize)
+    {
+        p1 = particleData.position[firstParticleIndex];
+        p2 = particleData.position[secondParticleIndex];
+
+        diff = p1 - p2;
+
+        c = length(diff) - distance[constraintIndex];
+    }
 
     vec3 grad = glm::normalize(diff);
     grad /= particleData.invmass[firstParticleIndex] + particleData.invmass[secondParticleIndex];

--- a/src/constraints/DistanceConstraintData.cpp
+++ b/src/constraints/DistanceConstraintData.cpp
@@ -42,7 +42,7 @@ bool DistanceConstraintData::solveDistanceConstraint(glm::vec3 & delta1, glm::ve
         return false;
 
     if (stabilize)
-    {
+    {   // Calculate delta with position instead of pPosition
         p1 = particleData.position[firstParticleIndex];
         p2 = particleData.position[secondParticleIndex];
 

--- a/src/constraints/DistanceConstraintData.h
+++ b/src/constraints/DistanceConstraintData.h
@@ -28,7 +28,7 @@ public:
 
     float evaluate(int constraintIndex, ParticleData &particleData);
 
-    bool solveDistanceConstraint(glm::vec3 &delta1, glm::vec3 &delta2, int constraintIndex, ParticleData &particleData);
+    bool solveDistanceConstraint(glm::vec3 &delta1, glm::vec3 &delta2, int constraintIndex, ParticleData &particleData, bool stabilize);
 
     void clear();
     void removeBroken(ParticleData &particleData);
@@ -50,7 +50,7 @@ public:
             std::vector<vec3> &pPosition = particles.pPosition;
             for (size_t constraintIndex = r.begin(); constraintIndex != r.end(); ++constraintIndex)
             {
-                if (distanceConstraints.solveDistanceConstraint(delta1, delta2, constraintIndex, particles))
+                if (distanceConstraints.solveDistanceConstraint(delta1, delta2, constraintIndex, particles, false))
                 {
                     ivec2 &constraintParticles = distanceConstraints.particles[constraintIndex];
                     int p1 = constraintParticles[0];

--- a/src/constraints/PlaneCollisionConstraintData.cpp
+++ b/src/constraints/PlaneCollisionConstraintData.cpp
@@ -9,12 +9,15 @@ PlaneCollisionConstraintData::PlaneCollisionConstraintData()
 	cardinality = 0;
 }
 
-bool PlaneCollisionConstraintData::solvePlaneCollision(glm::vec3 & delta, const int idx, ParticleData & particleData)
+bool PlaneCollisionConstraintData::solvePlaneCollision(glm::vec3 & delta, const int idx, ParticleData & particleData, bool stabilize)
 {
 	float c = glm::dot(normals[idx], particleData.pPosition[particles[idx]]) - distances[idx];
 
 	if (c > 0)
 		return false;
+
+    if (stabilize)
+        c = glm::dot(normals[idx], particleData.position[particles[idx]]) - distances[idx];
 
 	delta = c * normals[idx];
 	return true;

--- a/src/constraints/PlaneCollisionConstraintData.cpp
+++ b/src/constraints/PlaneCollisionConstraintData.cpp
@@ -16,7 +16,7 @@ bool PlaneCollisionConstraintData::solvePlaneCollision(glm::vec3 & delta, const 
 	if (c > 0)
 		return false;
 
-    if (stabilize)
+    if (stabilize) // Calculate delta with position instead of pPosition
         c = glm::dot(normals[idx], particleData.position[particles[idx]]) - distances[idx];
 
 	delta = c * normals[idx];

--- a/src/constraints/PlaneCollisionConstraintData.h
+++ b/src/constraints/PlaneCollisionConstraintData.h
@@ -30,7 +30,7 @@ public:
 	std::vector<glm::vec3> normals;
 	std::vector<float> distances;
 
-	bool solvePlaneCollision(glm::vec3 &delta, const int idx, ParticleData &particleData);
+	bool solvePlaneCollision(glm::vec3 &delta, const int idx, ParticleData &particleData, bool stabilize);
 
     void addConstraint(PlaneCollisionConstraint &config);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,7 +143,7 @@ void init() {
     physicSystem = Physics();
 
     physicSystem.iterations = 5;
-    physicSystem.collisionIterations = 3;
+    physicSystem.stabilizationIterations = 3;
     physicSystem.pSleeping = 0.0001f;
     physicSystem.overRelaxConst = 1.0f;
     physicSystem.restitutionCoefficientT = 0.8f; 
@@ -258,7 +258,7 @@ void gui()
     ImGui::Checkbox("Apply windlike force", &scene->windActive);
     ImGui::Checkbox("Render surfaces", &renderSurfaces);
     ImGui::SliderInt("Solver Iterations", &physicSystem.iterations, 1, 32);
-    ImGui::SliderInt("Collision Solver Iterations", &physicSystem.collisionIterations, 1, 32);
+    ImGui::SliderInt("Collision Stabilization Iterations", &physicSystem.stabilizationIterations, 0, 32);
     ImGui::SliderFloat("Over-relax-constant", &physicSystem.overRelaxConst, 1, 5);
     ImGui::SliderFloat("Particle Sleeping (squared)", &physicSystem.pSleeping, 0, 1, "%.9f", 10.f);
     ImGui::SliderFloat("Tangential COR", &physicSystem.restitutionCoefficientT, -1, 1);

--- a/src/models/Box.cpp
+++ b/src/models/Box.cpp
@@ -20,7 +20,6 @@ void Box::makeBox(ParticleData &particles, ConstraintData &constraints, model::M
     // Get the "minimum" corner to use as base position
     vec3 base_pos = config.centerPos - (config.scale * 0.5f);
 
-    int ph = 0;
     // Create particles
     for (int i = 0; i < config.numParticles.x; i++) {
         for (int j = 0; j < config.numParticles.y; j++) {

--- a/src/models/Box.cpp
+++ b/src/models/Box.cpp
@@ -20,6 +20,7 @@ void Box::makeBox(ParticleData &particles, ConstraintData &constraints, model::M
     // Get the "minimum" corner to use as base position
     vec3 base_pos = config.centerPos - (config.scale * 0.5f);
 
+    int ph = 0;
     // Create particles
     for (int i = 0; i < config.numParticles.x; i++) {
         for (int j = 0; j < config.numParticles.y; j++) {

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -156,7 +156,8 @@ void Physics::resolveConstraints(std::vector<glm::vec3> & position, std::vector<
         */
         vec3 delta1(0);
         vec3 delta2(0);
-        for (int i = 0; i < planeConstraints.cardinality; i++) {
+        for (int i = 0; i < planeConstraints.cardinality; i++)
+        {
             if (planeConstraints.solvePlaneCollision(delta1, i, particles, false))
             {
                 int p = planeConstraints.particles[i];
@@ -164,6 +165,9 @@ void Physics::resolveConstraints(std::vector<glm::vec3> & position, std::vector<
             }
         }
 
+        /**
+        * Particle Collision Constraints
+        */
         for (int i = 0; i < particleConstraints.cardinality; i++)
         {
             if (particleConstraints.solveDistanceConstraint(delta1, delta2, i, particles, false))
@@ -213,7 +217,8 @@ void Physics::resolveCollisions(std::vector<glm::vec3> & position, std::vector<g
     vec3 delta2(0);
     for (int j = 0; j < stabilizationIterations; j++)
     {
-        for (int i = 0; i < planeConstraints.cardinality; i++) {
+        for (int i = 0; i < planeConstraints.cardinality; i++)
+        {
             if (planeConstraints.solvePlaneCollision(delta1, i, particles, true))
             {
                 int p = planeConstraints.particles[i];

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -175,8 +175,7 @@ void Physics::resolveConstraints(std::vector<glm::vec3> & position, std::vector<
 
                 // Friction
                 glm::vec3 contactNormal = (pPosition[p1] - pPosition[p2]) / length(pPosition[p1] - pPosition[p2]); //-delta1 / d;
-                                                                                                                   // d = distance along the collision normal that the particles are projected
-                float d = length(delta1 * overRelaxConst);
+                float d = length(delta1 * overRelaxConst); // distance along the collision normal that the particles are projected
                 glm::vec3 v = (pPosition[p1] - position[p1]) - (pPosition[p2] - position[p2]);
                 glm::vec3 tangentialDelta = v - (dot(v, contactNormal) * contactNormal); // [(px[i] - x[i]) - (px[j] - x[j])] tangential to n
                 glm::vec3 frictionalPosDelta = (invmass[p1] / (invmass[p1] + invmass[p2])) * tangentialDelta;
@@ -212,7 +211,7 @@ void Physics::resolveCollisions(std::vector<glm::vec3> & position, std::vector<g
 {
     vec3 delta1(0);
     vec3 delta2(0);
-    for (int j = 0; j < collisionIterations; j++)
+    for (int j = 0; j < stabilizationIterations; j++)
     {
         for (int i = 0; i < planeConstraints.cardinality; i++) {
             if (planeConstraints.solvePlaneCollision(delta1, i, particles, true))
@@ -233,21 +232,6 @@ void Physics::resolveCollisions(std::vector<glm::vec3> & position, std::vector<g
                 pPosition[p1] -= delta1 * overRelaxConst;
                 position[p2]  -= delta2 * overRelaxConst;
                 pPosition[p2] -= delta2 * overRelaxConst;
-
-                // Friction
-                glm::vec3 contactNormal = (pPosition[p1] - pPosition[p2]) / length(pPosition[p1] - pPosition[p2]); //-delta1 / d;
-                // d = distance along the collision normal that the particles are projected
-                float d = length(delta1 * overRelaxConst);
-                glm::vec3 v = (pPosition[p1] - position[p1]) - (pPosition[p2] - position[p2]);
-                glm::vec3 tangentialDelta = v - (dot(v, contactNormal) * contactNormal); // [(px[i] - x[i]) - (px[j] - x[j])] tangential to n
-                glm::vec3 frictionalPosDelta = (invmass[p1] / (invmass[p1] + invmass[p2])) * tangentialDelta;
-                if (length(tangentialDelta) >= (staticFC * d)) // Is particles relative velocity above traction threshold?
-                    frictionalPosDelta *= min(kineticFC * d / length(tangentialDelta), 1); // if so, apply Columb friction
-                
-                position[p1]  += frictionalPosDelta;
-                pPosition[p1] += frictionalPosDelta;
-                position[p2]  -= frictionalPosDelta * invmass[p2] / (invmass[p1] + invmass[p2]);
-                pPosition[p2] -= frictionalPosDelta * invmass[p2] / (invmass[p1] + invmass[p2]);
             }
         }
     }

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -59,7 +59,7 @@ void Physics::step(Scene *scene, float dt)
     performance::stopTimer(id);
 
     id = performance::startTimer("Solve constraints");
-    resolveConstraints(pPosition, invmass, numBoundConstraints);
+    resolveConstraints(position, pPosition, invmass, numBoundConstraints, constraints.planeCollisionConstraints, constraints.particleCollisionConstraints);
     performance::stopTimer(id);
 
     for (std::vector<glm::vec3>::size_type i = 0; i != particles.cardinality; i++) 
@@ -96,7 +96,7 @@ void Physics::step(Scene *scene, float dt)
 
 }
 
-void Physics::resolveConstraints(std::vector<glm::vec3> & pPosition, std::vector<float> & invmass, std::vector<int> & numBoundConstraints)
+void Physics::resolveConstraints(std::vector<glm::vec3> & position, std::vector<glm::vec3> & pPosition, std::vector<float> & invmass, std::vector<int> & numBoundConstraints, PlaneCollisionConstraintData & planeConstraints, DistanceConstraintData & particleConstraints)
 {
     DistanceConstraintData &distanceConstraints = constraints.distanceConstraints;
     for (int i = 0; i < iterations; i++)
@@ -114,7 +114,7 @@ void Physics::resolveConstraints(std::vector<glm::vec3> & pPosition, std::vector
             vec3 delta2(0);
             for (int constraintIndex = 0; constraintIndex < distanceConstraints.cardinality; constraintIndex++)
             {
-                if (distanceConstraints.solveDistanceConstraint(delta1, delta2, constraintIndex, particles))
+                if (distanceConstraints.solveDistanceConstraint(delta1, delta2, constraintIndex, particles, false))
                 {
                     // delta p_i = -w_i * s * grad_{p_i} C(p) * stiffness correction 
                     ivec2 &constraintParticles = distanceConstraints.particles[constraintIndex];
@@ -150,6 +150,43 @@ void Physics::resolveConstraints(std::vector<glm::vec3> & pPosition, std::vector
                 pPosition[p] -= delta * overRelaxConst / (float)numBoundConstraints[p];
             }
         }
+
+        /**
+        * Plane Collision Constraints
+        */
+        vec3 delta1(0);
+        vec3 delta2(0);
+        for (int i = 0; i < planeConstraints.cardinality; i++) {
+            if (planeConstraints.solvePlaneCollision(delta1, i, particles, false))
+            {
+                int p = planeConstraints.particles[i];
+                pPosition[p] -= delta1 * overRelaxConst;
+            }
+        }
+
+        for (int i = 0; i < particleConstraints.cardinality; i++)
+        {
+            if (particleConstraints.solveDistanceConstraint(delta1, delta2, i, particles, false))
+            {
+                int p1 = particleConstraints.particles[i][0];
+                int p2 = particleConstraints.particles[i][1];
+                pPosition[p1] -= delta1 * overRelaxConst;
+                pPosition[p2] -= delta2 * overRelaxConst;
+
+                // Friction
+                glm::vec3 contactNormal = (pPosition[p1] - pPosition[p2]) / length(pPosition[p1] - pPosition[p2]); //-delta1 / d;
+                                                                                                                   // d = distance along the collision normal that the particles are projected
+                float d = length(delta1 * overRelaxConst);
+                glm::vec3 v = (pPosition[p1] - position[p1]) - (pPosition[p2] - position[p2]);
+                glm::vec3 tangentialDelta = v - (dot(v, contactNormal) * contactNormal); // [(px[i] - x[i]) - (px[j] - x[j])] tangential to n
+                glm::vec3 frictionalPosDelta = (invmass[p1] / (invmass[p1] + invmass[p2])) * tangentialDelta;
+                if (length(tangentialDelta) >= (staticFC * d)) // Is particles relative velocity above traction threshold?
+                    frictionalPosDelta *= min(kineticFC * d / length(tangentialDelta), 1); // if so, apply Columb friction
+
+                pPosition[p1] += frictionalPosDelta;
+                pPosition[p2] -= frictionalPosDelta * invmass[p2] / (invmass[p1] + invmass[p2]);
+            }
+        }
     }
 }
 
@@ -178,7 +215,7 @@ void Physics::resolveCollisions(std::vector<glm::vec3> & position, std::vector<g
     for (int j = 0; j < collisionIterations; j++)
     {
         for (int i = 0; i < planeConstraints.cardinality; i++) {
-            if (planeConstraints.solvePlaneCollision(delta1, i, particles))
+            if (planeConstraints.solvePlaneCollision(delta1, i, particles, true))
             {
                 int p = planeConstraints.particles[i];
                 position[p] -= delta1 * overRelaxConst;
@@ -188,11 +225,13 @@ void Physics::resolveCollisions(std::vector<glm::vec3> & position, std::vector<g
 
         for (int i = 0; i < particleConstraints.cardinality; i++)
         {
-            if (particleConstraints.solveDistanceConstraint(delta1, delta2, i, particles))
+            if (particleConstraints.solveDistanceConstraint(delta1, delta2, i, particles, true))
             {
                 int p1 = particleConstraints.particles[i][0];
                 int p2 = particleConstraints.particles[i][1];
+                position[p1]  -= delta1 * overRelaxConst;
                 pPosition[p1] -= delta1 * overRelaxConst;
+                position[p2]  -= delta2 * overRelaxConst;
                 pPosition[p2] -= delta2 * overRelaxConst;
 
                 // Friction
@@ -205,7 +244,9 @@ void Physics::resolveCollisions(std::vector<glm::vec3> & position, std::vector<g
                 if (length(tangentialDelta) >= (staticFC * d)) // Is particles relative velocity above traction threshold?
                     frictionalPosDelta *= min(kineticFC * d / length(tangentialDelta), 1); // if so, apply Columb friction
                 
+                position[p1]  += frictionalPosDelta;
                 pPosition[p1] += frictionalPosDelta;
+                position[p2]  -= frictionalPosDelta * invmass[p2] / (invmass[p1] + invmass[p2]);
                 pPosition[p2] -= frictionalPosDelta * invmass[p2] / (invmass[p1] + invmass[p2]);
             }
         }

--- a/src/physics.h
+++ b/src/physics.h
@@ -33,7 +33,7 @@ public:
     float staticFC; // static friction coefficient
 
     int iterations;
-	int collisionIterations;
+	int stabilizationIterations;
 
     ParticleData particles;
     ConstraintData constraints;

--- a/src/physics.h
+++ b/src/physics.h
@@ -45,7 +45,7 @@ private:
     /*
         Stationary iterative linear solver - Gauss-Seidel
     */
-    void resolveConstraints(std::vector<glm::vec3> & pPosition, std::vector<float> & invmass, std::vector<int> & numBoundConstraints);
+    void resolveConstraints(std::vector<glm::vec3> & position, std::vector<glm::vec3> & pPosition, std::vector<float> & invmass, std::vector<int> & numBoundConstraints, PlaneCollisionConstraintData & planeConstraints, DistanceConstraintData & particleConstraints);
 
     void dampPlaneCollision(std::vector<int> & numBoundConstraints, std::vector<glm::vec3> & velocity, PlaneCollisionConstraintData & triangleConstraints);
 


### PR DESCRIPTION
- During the collision stabilization pass the deltas are calculated with position rather than currently predicted position.
- Friction is applied during constraint solve and NOT during stabilization pass.
- Collision constraints used during stabilization pass are also used during the main constraint solve.